### PR TITLE
Remove useless type check + isolate tests.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,7 @@
     backupGlobals="false"
     colors="true"
     bootstrap="tests/bootstrap.php"
+    processIsolation="true"
 >
     <testsuites>
         <testsuite name="TestSuite">

--- a/src/Cerberus/Handler/Handler.php
+++ b/src/Cerberus/Handler/Handler.php
@@ -15,11 +15,6 @@ abstract class Handler implements HandlerInterface
 
     public function setErrorHandler(ErrorHandler $errorHandler)
     {
-        if (!$errorHandler instanceof ErrorHandler) {
-            throw new \InvalidArgumentException(
-                "Argument to ".__METHOD__." must be an instance of Cerberus\\ErrorHandler"
-            );
-        }
         $this->errorHandler = $errorHandler;
     }
 

--- a/src/Cerberus/Handler/HandlerList.php
+++ b/src/Cerberus/Handler/HandlerList.php
@@ -16,12 +16,6 @@ class HandlerList extends \SplDoublyLinkedList
 
     public function __construct(ErrorHandler $errorHandler, $defaultPriority = 10)
     {
-        if (!$errorHandler instanceof ErrorHandler) {
-            throw new \InvalidArgumentException(
-                "Argument to ".__METHOD__." must be an instance of Cerberus\\ErrorHandler"
-            );
-        }
-
         $this->errorHandler = $errorHandler;
         $this->priority = $defaultPriority;
         $this->heap = new HandlerHeap();
@@ -30,12 +24,6 @@ class HandlerList extends \SplDoublyLinkedList
 
     public function addHandler(HandlerInterface $handler)
     {
-        if (!$handler instanceof HandlerInterface) {
-            throw new \InvalidArgumentException(
-                "Argument to ".__METHOD__." must be an instance of Cerberus\\Handler\\HandlerInterface"
-            );
-        }
-
         $handler->setErrorHandler($this->errorHandler);
         if (-1 === $handler->getPriority()) {
             $handler->setPriority($this->priority);

--- a/tests/Cerberus/Tests/ErrorHandlerTest.php
+++ b/tests/Cerberus/Tests/ErrorHandlerTest.php
@@ -37,19 +37,6 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->eh->getThrowNonFatal());
     }
 
-    public function testBadHandler()
-    {
-        $this->setExpectedException('InvalidArgumentException');
-        $this->eh->addHandler('BAD.HANDLER');
-    }
-
-    public function testBadErrorHandler()
-    {
-        $handler = new MockHandler();
-        $this->setExpectedException('InvalidArgumentException');
-        $handler->setErrorHandler('BAD.ERROR_HANDLER');
-    }
-
     public function testNoHandler()
     {
         $handler = new MockHandler();


### PR DESCRIPTION
I removed the `instanceof` check in some methods, as this is a native language feature. 
It's useless to test this, so I removed the tests. 

Also, I isolated tests, as without isolation, error handlers are stacking. 

